### PR TITLE
Kevin/radio options

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -174,6 +174,7 @@ globals:
   NSStackView: false
   NSUserInterfaceLayoutOrientationVertical: false
   NSLayoutAttributeLeading: false
+  NSStackViewGravityLeading: false
 
 rules:
   ###########

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -168,6 +168,12 @@ globals:
   NSTextView: false
   NSMakeSize: false
   NSPopUpButton: false
+  NSButton: false
+  NSRadioButton: false
+  NSOnState: false
+  NSStackView: false
+  NSUserInterfaceLayoutOrientationVertical: false
+  NSLayoutAttributeLeading: false
 
 rules:
   ###########

--- a/Source/ui/UI.js
+++ b/Source/ui/UI.js
@@ -172,7 +172,6 @@ export function getInputFromUser(messageText, options, callback) {
       break
     }
     case INPUT_TYPE.selection: {
-
       console.log('triggered')
 
       if (!util.isArray(options.possibleValues)) {

--- a/Source/ui/UI.js
+++ b/Source/ui/UI.js
@@ -172,6 +172,9 @@ export function getInputFromUser(messageText, options, callback) {
       break
     }
     case INPUT_TYPE.selection: {
+
+      console.log('triggered')
+
       if (!util.isArray(options.possibleValues)) {
         throw new Error(
           'When the input type is `selection`, you need to provide the array of possible choices.'

--- a/Source/ui/UI.js
+++ b/Source/ui/UI.js
@@ -177,11 +177,44 @@ export function getInputFromUser(messageText, options, callback) {
           'When the input type is `selection`, you need to provide the array of possible choices.'
         )
       }
-      accessory = NSPopUpButton.alloc().initWithFrame(NSMakeRect(0, 0, 295, 25))
-      accessory.addItemsWithTitles(options.possibleValues)
-      const initialIndex = options.possibleValues.indexOf(options.initialValue)
-      accessory.selectItemAtIndex(initialIndex !== -1 ? initialIndex : 0)
-      break
+
+      // think I need this to bind the options together?
+      const radioOptionTargetFunction = sender => {
+        console.log('radio button was clicked', sender.title())
+      }
+
+      if (options.radioStyle == true) {
+        const radioOptionsArray = options.possibleValues.map((value, index) => {
+          const radioOption = NSButton.alloc().init()
+          radioOption.setButtonType(NSRadioButton)
+          radioOption.setTitle(value)
+          // is initialValue an integer or string?
+          if (options.initialValue == value || options.initialValue == index) {
+            radioOption.setState(NSOnState)
+          }
+          radioOption.setCOSJSTargetFunction(sender =>
+            radioOptionTargetFunction(sender)
+          )
+          return radioOption
+        })
+
+        accessory = NSStackView.stackViewWithViews(radioOptionsArray)
+        accessory.setOrientation(NSUserInterfaceLayoutOrientationVertical)
+        accessory.setAlignment(NSLayoutAttributeLeading)
+        accessory.setSpacing(4)
+        accessory.setTranslatesAutoresizingMaskIntoConstraints(false)
+        break
+      } else {
+        accessory = NSPopUpButton.alloc().initWithFrame(
+          NSMakeRect(0, 0, 295, 25)
+        )
+        accessory.addItemsWithTitles(options.possibleValues)
+        const initialIndex = options.possibleValues.indexOf(
+          options.initialValue
+        )
+        accessory.selectItemAtIndex(initialIndex !== -1 ? initialIndex : 0)
+        break
+      }
     }
     default:
       break

--- a/package-lock.json
+++ b/package-lock.json
@@ -1738,7 +1738,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2380,7 +2380,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2393,7 +2393,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2652,7 +2652,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -7300,7 +7300,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -7695,7 +7695,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -7938,7 +7938,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -7953,7 +7953,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {


### PR DESCRIPTION
[WIP]

From feedback in #316

By specifying the radio option variant for `INPUT_TYPE.selection` a developer can change the selection style.

Example:

Will need to pass extra parameter `radioStyle:true`

``` javascript
let UI = require('sketch').UI

UI.getInputFromUser("What's your favorite design tool?", {
  type: UI.INPUT_TYPE.selection,
  possibleValues: ['Something really long and aweful goes here and not sure what happens', 'Sketch', 'Hello'],
  radioStyle: true,
}, (err, value) => {
  if (err) {
    // most likely the user canceled the input
    console.error(err)
    return
  }
  console.log("selected value is: " + value)
})
```

Current concerns:

- [ ] Unsure what the best way to specify the UI type for selection (dropdown vs radio options). Want something that won’t break old code but allows for future expansion.
- [ ] Last? radio option can be highlighted
![Sep-17-2019 01-32-13](https://user-images.githubusercontent.com/4199296/65025145-04be3800-d8eb-11e9-9f52-64685377b651.gif)
- [ ] Had to disable linter warning on line [278](https://github.com/BohemianCoding/SketchAPI/compare/develop...KevinGutowski:kevin/radio_options?expand=1#diff-1165cabb99c47300408a4c1126da287fR278) Maybe try not using a for loop?
- [ ] Truncate clipped text