### PR TITLE
polyfill process.argv

### DIFF
--- a/core-modules/package.json
+++ b/core-modules/package.json
@@ -14,7 +14,7 @@
     "@skpm/events": "0.2.0",
     "@skpm/os": "0.1.1",
     "@skpm/path": "0.1.4",
-    "@skpm/process": "0.1.3",
+    "@skpm/process": "0.1.4",
     "@skpm/querystring": "0.1.0",
     "@skpm/stream": "0.1.4",
     "@skpm/string_decoder": "0.1.5",


### PR DESCRIPTION
some npm packages are checking `process.argv` which should return an array.
`@skpm/process@0.1.4` now returns `["/path/to/Sketch.app", "/path/to/plugin.sketchplugin", context]`