### PR TITLE
Fixes shared style and symbols docs using same headings

### DIFF
--- a/docs/api/SharedStyle.md
+++ b/docs/api/SharedStyle.md
@@ -76,7 +76,7 @@ Returns an array of all layers with a Style which is an instance of the Shared S
 
 A [Layer](#layer) array.
 
-## Get the Library it was defined in
+## Get Library defining the style
 
 ```javascript
 var originLibrary = sharedStyle.getLibrary()

--- a/docs/api/SymbolMaster.md
+++ b/docs/api/SymbolMaster.md
@@ -83,7 +83,7 @@ var instances = master.getAllInstances()
 
 Returns an array of all instances of the symbol in the document, on all pages.
 
-## Get the Library it was defined in
+## Get Library defining the Symbol Master
 
 ```javascript
 var originLibrary = master.getLibrary()


### PR DESCRIPTION
Identical headings result in ambiguous anchors:

> “Symbol Master > Get the library it was defined in” does actually link to “Shared Style > Get the library it was defined in”