### PR TITLE
Accommodate Sketch model change that adds a new text layer line spacing behaviour

### DIFF
--- a/Source/dom/layers/Text.js
+++ b/Source/dom/layers/Text.js
@@ -12,13 +12,13 @@ const TextBehaviour = {
 const TextLineSpacingBehaviour = {
   variable: 'variable', // Uses min & max line height on paragraph style
   constantBaseline: 'constantBaseline', // Uses MSConstantBaselineTypesetter for fixed line height
-  natural: 'natural' // Uses MSConstantBaselineTypesetter for fixed line heights, and MSEmojiAwareLayoutManagerDelegate for natural line heights
+  natural: 'natural', // Uses MSConstantBaselineTypesetter for fixed line heights, and MSEmojiAwareLayoutManagerDelegate for natural line heights
 }
 
 export const TextLineSpacingBehaviourMap = {
   variable: 1, // Uses min & max line height on paragraph style
   constantBaseline: 2, // Uses MSConstantBaselineTypesetter for fixed line height
-  natural: 3 // Uses MSConstantBaselineTypesetter for fixed line heights, and MSEmojiAwareLayoutManagerDelegate for natural line heights  
+  natural: 3, // Uses MSConstantBaselineTypesetter for fixed line heights, and MSEmojiAwareLayoutManagerDelegate for natural line heights
 }
 
 // Mapping between text alignment names and values.

--- a/Source/dom/layers/Text.js
+++ b/Source/dom/layers/Text.js
@@ -12,11 +12,13 @@ const TextBehaviour = {
 const TextLineSpacingBehaviour = {
   variable: 'variable', // Uses min & max line height on paragraph style
   constantBaseline: 'constantBaseline', // Uses MSConstantBaselineTypesetter for fixed line height
+  natural: 'natural' // Uses MSConstantBaselineTypesetter for fixed line heights, and MSEmojiAwareLayoutManagerDelegate for natural line heights
 }
 
 export const TextLineSpacingBehaviourMap = {
   variable: 1, // Uses min & max line height on paragraph style
   constantBaseline: 2, // Uses MSConstantBaselineTypesetter for fixed line height
+  natural: 3 // Uses MSConstantBaselineTypesetter for fixed line heights, and MSEmojiAwareLayoutManagerDelegate for natural line heights  
 }
 
 // Mapping between text alignment names and values.

--- a/Source/dom/layers/__tests__/Text.test.js
+++ b/Source/dom/layers/__tests__/Text.test.js
@@ -57,7 +57,7 @@ test('should change the line spacing behavior', () => {
   })
 
   // default to constant baseline
-  expect(text.lineSpacing).toBe(Text.LineSpacing.constantBaseline)
+  expect(text.lineSpacing).toBe(Text.LineSpacing.natural)
 
   Object.keys(Text.LineSpacing).forEach((key) => {
     // test setting by name


### PR DESCRIPTION
Mapped the new Emoji-aware (v4) behaviour to a "natural" line spacing behaviour constant in JavaScript.

Connect sketch-hq/Sketch#24338