### PR TITLE
Fix duplicate anchor

### DIFF
--- a/docs/api/SymbolInstance.md
+++ b/docs/api/SymbolInstance.md
@@ -89,7 +89,7 @@ Change the value of the override.
 
 The current Symbol instance (useful if you want to chain the calls).
 
-## Trigger a Smart Layout
+## Resize with Smart Layout
 
 ```javascript
 instance.resizeWithSmartLayout()


### PR DESCRIPTION
There were two anchors for resizing a symbolInstance to match the auto layout (“both were `#trigger-a-smart-layout`. I tweaked the heading so that the anchors weren’t matching anymore.