### PR TITLE
Re-add referencingColor method, which was somehow lost in the last merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
-- [Fixed] Return `system` font family name correctly on macOS 10.15
-
 ## Releases
+
+### Sketch 69
+
+- [New] Color Variables API.
+
+### Sketch 67
+
+- [Fixed] Return `system` font family name correctly on macOS 10.15
 
 ### Sketch 65
 

--- a/Source/dom/assets/Swatch.js
+++ b/Source/dom/assets/Swatch.js
@@ -64,3 +64,8 @@ Swatch.define('color', {
     return colorToString(this._object.color())
   },
 })
+Swatch.define('referencingColor', {
+  get() {
+    return this._object.makeReferencingColor()
+  },
+})

--- a/Source/dom/assets/__tests__/Swatch.test.js
+++ b/Source/dom/assets/__tests__/Swatch.test.js
@@ -54,3 +54,11 @@ test('should create swatch from MSSwatch', () => {
   expect(swatch.color).toBe('#ffffffff')
   expect(swatch.name).toBe('#ffffff')
 })
+
+test('should create referencing color', () => {
+  const swatch = Swatch.from({
+    name: 'Safety Orange',
+    color: '#ff6600'
+  })
+  expect(swatch.referencingColor.isKindOfClass(MSColor)).toBeTruthy()
+})


### PR DESCRIPTION
Connect https://github.com/sketch-hq/Sketch/pull/32818