### PR TITLE
Ensure to show message only on instances of MSDocument

### DIFF
--- a/Source/ui/UI.js
+++ b/Source/ui/UI.js
@@ -18,16 +18,14 @@ function getPluginAlertIcon() {
  * @param [Document] document The document in which we will show the message
  */
 export function message(text, document) {
-  if (!document) {
-    NSApplication.sharedApplication()
-      .orderedDocuments()
-      .firstObject()
-      .showMessage(text)
-  } else if (util.isNativeObject(document)) {
-    document.showMessage(text)
-  } else {
-    document.sketchObject.showMessage(text)
-  }
+  document = document
+    ? document.sketchObject || document // Drop down to native object if required
+    : NSApplication.sharedApplication().orderedDocuments().firstObject()
+
+  // Only documents have `showMessage` API
+  if (!(document instanceof MSDocument)) return
+
+  document.showMessage(text)
 }
 
 /**


### PR DESCRIPTION
Bail early for anything that isn't `MSDocument` or if nil to prevent unsupported calls to `showMessage`.

Connect sketch-hq/Sketch#37385