### PR TITLE
Define property Flow.maintainScrollPosition

### DIFF
--- a/Source/dom/models/Flow.js
+++ b/Source/dom/models/Flow.js
@@ -113,5 +113,17 @@ Flow.define('animationType', {
   },
 })
 
+Flow.define('maintainScrollPosition', {
+  get() {
+    return Boolean(this._object.maintainScrollPosition());
+  },
+  set(maintainScrollPosition) {
+    if (this.isImmutable()) {
+      return
+    }
+    this._object.setMaintainScrollPosition(maintainScrollPosition)
+  },
+})
+
 // override the WrappedObject id
 delete Flow[DefinedPropertiesKey].id

--- a/Source/dom/models/Flow.js
+++ b/Source/dom/models/Flow.js
@@ -121,6 +121,11 @@ Flow.define('maintainScrollPosition', {
     if (this.isImmutable()) {
       return
     }
+
+    if (typeof maintainScrollPosition !== 'boolean') {
+      throw new Error('`maintainScrollPosition` must be a boolean value.');
+    }
+
     this._object.setMaintainScrollPosition(maintainScrollPosition)
   },
 })

--- a/Source/dom/models/__tests__/Flow.test.js
+++ b/Source/dom/models/__tests__/Flow.test.js
@@ -140,7 +140,7 @@ test('should create a back action', () => {
   expect(rect.flow.isBackAction()).toBe(true)
 })
 
-test('adding a flow action with an unknow target work but isValidConnection should return false', () => {
+test('adding a flow action with an unknown target work but isValidConnection should return false', () => {
   const artboard = new Artboard({ name: 'Test1' })
 
   const rect = new Group({

--- a/Source/dom/models/__tests__/Flow.test.js
+++ b/Source/dom/models/__tests__/Flow.test.js
@@ -91,14 +91,23 @@ test('maintain scroll position should persist', (_context, document) => {
       targetId: artboard2.id,
       maintainScrollPosition: true,
     },
-  })
+  });
 
   expect(rect.flow.toJSON()).toEqual({
     targetId: artboard2.id,
     type: 'Flow',
     animationType: 'slideFromRight',
     maintainScrollPosition: true,
-  })
+  });
+
+  rect.flow.maintainScrollPosition = false;
+
+  expect(rect.flow.toJSON()).toEqual({
+    targetId: artboard2.id,
+    type: 'Flow',
+    animationType: 'slideFromRight',
+    maintainScrollPosition: false,
+  });
 })
 
 test('should create a flow between a layer and an artboard with a specific animation', () => {

--- a/Source/dom/models/__tests__/Flow.test.js
+++ b/Source/dom/models/__tests__/Flow.test.js
@@ -24,6 +24,7 @@ test('should create a flow between a layer and an artboard with a default animat
     targetId: artboard2.id,
     type: 'Flow',
     animationType: 'slideFromRight',
+    maintainScrollPosition: false,
   })
   expect(rect.flow.isBackAction()).toBe(false)
   expect(rect.flow.isValidConnection()).toBe(true)
@@ -50,6 +51,7 @@ test('should create a flow between a layer and an artboard with a targetId', (_c
     targetId: artboard2.id,
     type: 'Flow',
     animationType: 'slideFromRight',
+    maintainScrollPosition: false,
   })
 })
 
@@ -73,6 +75,32 @@ test('target should return the wrapped artboard', (_context, document) => {
   expect(rect.flow.target).toEqual(artboard2)
 })
 
+test('maintain scroll position should persist', (_context, document) => {
+  const artboard = new Artboard({
+    name: 'Test1',
+    parent: document.selectedPage,
+  })
+  const artboard2 = new Artboard({
+    name: 'Test2',
+    parent: document.selectedPage,
+  })
+
+  const rect = new Group({
+    parent: artboard,
+    flow: {
+      targetId: artboard2.id,
+      maintainScrollPosition: true,
+    },
+  })
+
+  expect(rect.flow.toJSON()).toEqual({
+    targetId: artboard2.id,
+    type: 'Flow',
+    animationType: 'slideFromRight',
+    maintainScrollPosition: true,
+  })
+})
+
 test('should create a flow between a layer and an artboard with a specific animation', () => {
   const artboard = new Artboard({ name: 'Test1' })
   const artboard2 = new Artboard({ name: 'Test2' })
@@ -89,6 +117,7 @@ test('should create a flow between a layer and an artboard with a specific anima
     targetId: artboard2.id,
     type: 'Flow',
     animationType: 'slideFromLeft',
+    maintainScrollPosition: false,
   })
 })
 
@@ -106,6 +135,7 @@ test('should create a back action', () => {
     targetId: Flow.BackTarget,
     type: 'Flow',
     animationType: 'slideFromRight',
+    maintainScrollPosition: false,
   })
   expect(rect.flow.isBackAction()).toBe(true)
 })


### PR DESCRIPTION
Add the Flow.maintainScrollPosition property.

Sketch prototyping allows setting this property through the UI, but it's not available through the API.

I have added it to the best of my ability, and loading the API locally I can use it as expected in my plugin.

I have added the new property to Flow tests, as well as a specific test.