### PR TITLE
Get platform independent text alignment value

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -184,5 +184,6 @@
     "NSUUID": "readonly",
     "NSError": "readonly",
     "NSMapTable": "readonly",
+    "MSTextAlignmentConverter": "readonly",
   }
 }

--- a/Source/dom/style/Text.js
+++ b/Source/dom/style/Text.js
@@ -188,7 +188,12 @@ export function defineTextStyleProperties(Style) {
       }
 
       updateParagraphStyle(this._object, (paragraphStyle) => {
-        const translated = TextAlignmentMap[mode]
+        // Get a platform independent raw text alignment value
+        // NSTextAlignment is represented differently on Intel and M1 chips
+        const translated =
+          TextAlignmentMap[
+            MSTextAlignmentConverter.archiveNSTextAlignment(mode)
+          ]
         paragraphStyle.setAlignment(
           typeof translated !== 'undefined' ? translated : mode
         )

--- a/Source/dom/style/Text.js
+++ b/Source/dom/style/Text.js
@@ -175,7 +175,11 @@ export function defineTextStyleProperties(Style) {
         return undefined
       }
 
-      const raw = paragraphStyle.alignment()
+      // Get a platform independent raw text alignment value
+      // NSTextAlignment is represented differently on Intel and M1 chips
+      let raw = MSTextAlignmentConverter.archiveNSTextAlignment(
+        paragraphStyle.alignment()
+      )
       return TextAlignmentReverseMap[raw] || raw
     },
     set(mode) {

--- a/Source/dom/style/Text.js
+++ b/Source/dom/style/Text.js
@@ -190,13 +190,22 @@ export function defineTextStyleProperties(Style) {
       updateParagraphStyle(this._object, (paragraphStyle) => {
         const rawValue = TextAlignmentMap[mode]
 
+        const alignment = typeof rawValue === 'undefined' ? mode : rawValue
+
+        // Ensure our new alignment value is known because the Mac app crashes
+        // when using `archiveNSTextAlignent` with an unknown text alignment
+        // value
+        if (typeof TextAlignmentReverseMap[alignment] === 'undefined') {
+          return paragraphStyle
+        }
+
         // Get a platform independent raw text alignment value
         // NSTextAlignment is represented differently on Intel and M1 chips
-        const alignment = MSTextAlignmentConverter.archiveNSTextAlignment(
-          rawValue || mode
+        const platformIndependentAlignment = MSTextAlignmentConverter.archiveNSTextAlignment(
+          alignment
         )
 
-        paragraphStyle.setAlignment(alignment)
+        paragraphStyle.setAlignment(platformIndependentAlignment)
 
         return paragraphStyle
       })

--- a/Source/dom/style/Text.js
+++ b/Source/dom/style/Text.js
@@ -188,15 +188,16 @@ export function defineTextStyleProperties(Style) {
       }
 
       updateParagraphStyle(this._object, (paragraphStyle) => {
+        const rawValue = TextAlignmentMap[mode]
+
         // Get a platform independent raw text alignment value
         // NSTextAlignment is represented differently on Intel and M1 chips
-        const translated =
-          TextAlignmentMap[
-            MSTextAlignmentConverter.archiveNSTextAlignment(mode)
-          ]
-        paragraphStyle.setAlignment(
-          typeof translated !== 'undefined' ? translated : mode
+        const alignment = MSTextAlignmentConverter.archiveNSTextAlignment(
+          rawValue || mode
         )
+
+        paragraphStyle.setAlignment(alignment)
+
         return paragraphStyle
       })
     },


### PR DESCRIPTION
NSTextAlignment uses different numerical values for different
architectures. Using the raw value means we incorrectly report text
alignment on M1 machines.

This fixes the issue by using `MSTextAlignmentConverter` used internally
by Sketch.

connects https://github.com/sketch-hq/Sketch/issues/39019

Closes https://github.com/sketch-hq/SketchAPI/issues/860