### PR TITLE
Code Review: [SketchAPI] Support getting non-JSON values fro user defaults (#43719)

### DIFF
--- a/Source/settings/Settings.js
+++ b/Source/settings/Settings.js
@@ -23,7 +23,12 @@ export function globalSettingForKey(key) {
   if (typeof value === 'undefined' || value === 'undefined' || value === null) {
     return undefined
   }
-  return JSON.parse(value)
+
+  try {
+    return JSON.parse(value)
+  } catch (e) {
+    return util.toJSObject(value)
+  }
 }
 
 /**

--- a/Source/settings/Settings.js
+++ b/Source/settings/Settings.js
@@ -14,9 +14,10 @@ function getPluginIdentifier() {
  * @param key The setting to look up.
  * @return The setting value.
  *
- * This is equivalent to reading a setting for the currently
- * running version of Sketch using the `defaults` command line tool,
- * eg: defaults read com.bohemiancoding.sketch3 <key>
+ * When the global settings value is not JSON his is equivalent to reading a
+ * setting for the currently running version of Sketch using the `defaults`
+ * command line tool, eg: defaults read com.bohemiancoding.sketch3 <key>
+ * When the value is JSON than this will return the parsed JSON value instead.
  * */
 export function globalSettingForKey(key) {
   const value = NSUserDefaults.standardUserDefaults().objectForKey_(key)
@@ -36,10 +37,6 @@ export function globalSettingForKey(key) {
  *
  * @param key The setting to set.
  * @param value The value to set it to.
- *
- * This is equivalent to writing a setting for the currently
- * running version of Sketch using the `defaults` command line tool,
- * eg: defaults write com.bohemiancoding.sketch3 <key> <value>
  */
 export function setGlobalSettingForKey(key, value) {
   const store = NSUserDefaults.standardUserDefaults()

--- a/Source/settings/__tests__/Settings.test.js
+++ b/Source/settings/__tests__/Settings.test.js
@@ -3,6 +3,7 @@ import { Text } from '../../dom'
 import {
   settingForKey,
   setSettingForKey,
+  globalSettingForKey,
   setLayerSettingForKey,
   layerSettingForKey,
   setDocumentSettingForKey,
@@ -11,6 +12,13 @@ import {
 
 test('non existing settings should return undefined', () => {
   expect(settingForKey('non-existing-key')).toBe(undefined)
+})
+
+test(`returns raw value when value is not valid JSON`, () => {
+  const store = NSUserDefaults.standardUserDefaults()
+  store.setObject_forKey_('raw-string-value', 'raw-string-key')
+
+  expect(globalSettingForKey('raw-string-key')).toBe('raw-string-value')
 })
 
 test('should set a boolean', () => {


### PR DESCRIPTION
Fix `Setting.globalSettingForKey` returning `undefined` when the value in user defaults is not valid JSON. Also update some doc comments that incorrectly say that `globalSettingForKey` and `setGlobalSettingForKey` are the same as `defaults read` and `defaults write`.

Connect sketch-hq/sketch#43719