### PR TITLE
Fix Sketch API related to Smart Layout

### DIFF
--- a/Source/dom/layers/SymbolInstance.js
+++ b/Source/dom/layers/SymbolInstance.js
@@ -71,7 +71,7 @@ export class SymbolInstance extends StyledLayer {
       return this
     }
 		this._object.ensureDetachHasUpdated()
-    this._object.resizeToFitContentsIfNeededNoCache()
+    this._object.resizeToFitContentsIfNeeded()
     return this
   }
 }

--- a/Source/dom/layers/__tests__/SymbolInstance.test.js
+++ b/Source/dom/layers/__tests__/SymbolInstance.test.js
@@ -77,19 +77,19 @@ test('should detach an instance recursively', (_context, document) => {
   expect(group.type).toBe('Group')
 })
 
-// test('should resize in response to smart layout changes', (_context, document) => {
-//   const { master } = createSymbolMaster(document)
-//   master.smartLayout = SmartLayout.LeftToRight
-//   const instance = new SymbolInstance({
-//     symbolId: master.symbolId,
-//     parent: document.selectedPage,
-//   })
-//   const initialWidth = instance.frame.width
-//   instance.overrides[0].value = '0'.repeat(1000)
-//   instance.resizeWithSmartLayout()
-//   const widthAfterSmartLayout = instance.frame.width
-//   expect(widthAfterSmartLayout).toBeGreaterThan(initialWidth)
-// })
+test('should resize in response to smart layout changes', (_context, document) => {
+  const { master } = createSymbolMaster(document)
+  master.smartLayout = SmartLayout.LeftToRight
+  const instance = new SymbolInstance({
+    symbolId: master.symbolId,
+    parent: document.selectedPage,
+  })
+  const initialWidth = instance.frame.width
+  instance.overrides[0].value = 'A string that is long enough to cause a size change, hopefully in the positive direction'.repeat(1000)
+  instance.resizeWithSmartLayout()
+  const widthAfterSmartLayout = instance.frame.width
+  expect(widthAfterSmartLayout).toBeGreaterThan(initialWidth)
+})
 
 // test('should change an override value', (_context, document) => {
 //   const { master } = createSymbolMaster(document)


### PR DESCRIPTION
#### What does this pull request do?
This PR fixes `resizeWithSmartLayout()` in the Sketch API by making sure it calls the correct method internally.

It also restores the test that would have caught this bug.

#### Reviewer Notes
N/A

#### Tester Notes
N/A

#### How has this been tested?
 - [x] I have added unit/snapshot tests
 - [x] I have done extensive manual testing
 - [ ] I have tested the impact of these changes on accessibility

#### Screenshots (if appropriate)
N/A